### PR TITLE
Better filter + reformat

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :distribution :repo}
   :url "http://github.com/threatgrid/ring-jwt-middleware"
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [clj-jwt "0.1.1"]
+                 [yogsototh/clj-jwt "0.2.0"]
                  [threatgrid/clj-momo "0.2.9"]
                  [org.clojure/tools.logging "0.3.1"]
                  [metosin/ring-http-response "0.8.2"]

--- a/test/ring_jwt_middleware/core_test.clj
+++ b/test/ring_jwt_middleware/core_test.clj
@@ -351,6 +351,17 @@
                                    {:foo "bar"
                                     :bar "baz"})))
 
+  (is (nil? (sut/check-jwt-filter! #{{:scopes ["admin"]}}
+                                   {:foo "bar"
+                                    :scopes ["admin" "user"]})))
+
+  (is (try (sut/check-jwt-filter! #{{:scopes ["admin"]}}
+                                  {:foo "bar"
+                                   :scopes ["user"]})
+           false
+           (catch Exception e
+             true)))
+
   (is (try (sut/check-jwt-filter! #{{:foo "bar"} {:foo "baz"}}
                                   {:foo "quux"})
            false


### PR DESCRIPTION
The new filtering system will be able to handle `scopes`.

Typically if we want to reduce access to people having some scope now it will work easily.
Now the `jwt-filter`:

`:scopes ["admin"]` will accept users with scope `["admin" "otherscope"]`.

Also provide the ability to reformat the `jwt` into an `id-infos` internal data structure.
This is a necessity to clean the route format and separate concern between claim naming convention and internal code filtering. With this ability we'll be able to make changes to JWT format with much less consequence in all the route definitions than today.
