### PR TITLE
provide a way to support long lived JWT

### DIFF
--- a/README.org
+++ b/README.org
@@ -40,6 +40,7 @@ wrap your routes with it:
 | =:jwt-check-fn=            | a fn to custom check the JWT, should return a vec of error strings or nil              | nil                            |
 | =:no-jwt-handler=          | a middleware to pass when no JWT header is found  (=handler -> (request -> response)=) | forbid-no-jwt-header-strategy  |
 | =:post-jwt-format-fn=      | a fn that given a JWT generate an identity information                                 | jwt->user-id (the "sub" claim) |
+| =:long-lived-jwt?=         | a fn that given a JWT return true if we should check the max-lifetime false otherwise  | jwt->user-id (the "sub" claim) |
 
 If the request contains a valid JWT auth header, the JWT is merged with the ring
 request under a =:jwt= key as well with a =:identiy= key.

--- a/src/ring_jwt_middleware/core.clj
+++ b/src/ring_jwt_middleware/core.clj
@@ -114,6 +114,8 @@
 
 (def no-revocation-strategy (constantly false))
 
+(def no-long-lived-jwt (constantly false))
+
 (defn validate-jwt
   "Run both expiration and user checks,
   return a vec of errors or nothing"
@@ -137,7 +139,7 @@
                   (concat checks exp-vals)))))
 
   ([jwt jwt-max-lifetime-in-sec]
-   (validate-jwt jwt jwt-max-lifetime-in-sec nil (constantly false))))
+   (validate-jwt jwt jwt-max-lifetime-in-sec nil no-long-lived-jwt)))
 
 (defn forbid-no-jwt-header-strategy
   "Forbid all request with no Auth header"
@@ -178,8 +180,6 @@
              (cond-> {:id (get jwt (str prefix "/oauth/client/id"))}
                client-name (assoc :name client-name)))})
 
-
-(def no-long-lived-jwt (constantly false))
 
 (defn wrap-jwt-auth-fn
   "wrap a ring handler with JWT check"

--- a/src/ring_jwt_middleware/core.clj
+++ b/src/ring_jwt_middleware/core.clj
@@ -74,13 +74,17 @@
 
 (defn check-jwt-expiry
   "Return a string if JWT expiration check fails, nil otherwise"
-  [jwt jwt-max-lifetime-in-sec]
+  [jwt
+   jwt-max-lifetime-in-sec
+   long-lived-jwt?]
   (let [required-fields #{:nbf :exp :iat}
         jwt-keys (set (keys jwt))]
     (if (set/subset? required-fields jwt-keys)
       (let [now (time-coerce/to-epoch (time/now))
-            expired-secs (- now (+ (:iat jwt 0)
-                                   jwt-max-lifetime-in-sec))
+            expired-secs (if (long-lived-jwt? jwt)
+                           -1
+                           (- now (+ (:iat jwt 0)
+                                     jwt-max-lifetime-in-sec)))
             before-secs (- (:nbf jwt) now)
             expired-lifetime-secs (- now (:exp jwt 0))]
         (cond
@@ -115,9 +119,12 @@
   return a vec of errors or nothing"
   ([jwt
     jwt-max-lifetime-in-sec
-    jwt-check-fn]
-   (let [exp-vals [(check-jwt-expiry jwt (or jwt-max-lifetime-in-sec
-                                             default-jwt-lifetime-in-sec))]
+    jwt-check-fn
+    long-lived-jwt?]
+   (let [exp-vals [(check-jwt-expiry jwt
+                                     (or jwt-max-lifetime-in-sec
+                                         default-jwt-lifetime-in-sec)
+                                     long-lived-jwt?)]
          checks (if (fn? jwt-check-fn)
                   (or (try (jwt-check-fn jwt)
                            (catch Exception e
@@ -130,7 +137,7 @@
                   (concat checks exp-vals)))))
 
   ([jwt jwt-max-lifetime-in-sec]
-   (validate-jwt jwt jwt-max-lifetime-in-sec nil)))
+   (validate-jwt jwt jwt-max-lifetime-in-sec nil (constantly false))))
 
 (defn forbid-no-jwt-header-strategy
   "Forbid all request with no Auth header"
@@ -172,6 +179,8 @@
                client-name (assoc :name client-name)))})
 
 
+(def no-long-lived-jwt (constantly false))
+
 (defn wrap-jwt-auth-fn
   "wrap a ring handler with JWT check"
   [{:keys [pubkey-path
@@ -179,11 +188,13 @@
            jwt-check-fn
            jwt-max-lifetime-in-sec
            post-jwt-format-fn
-           no-jwt-handler]
+           no-jwt-handler
+           long-lived-jwt?]
     :or {jwt-max-lifetime-in-sec default-jwt-lifetime-in-sec
          is-revoked-fn no-revocation-strategy
          post-jwt-format-fn jwt->user-id
-         no-jwt-handler forbid-no-jwt-header-strategy}}]
+         no-jwt-handler forbid-no-jwt-header-strategy
+         long-lived-jwt? no-long-lived-jwt}}]
   (let [pubkey (public-key pubkey-path)
         is-revoked-fn (if (fn? is-revoked-fn)
                         is-revoked-fn
@@ -195,7 +206,10 @@
           (if-let [raw-jwt (get-jwt request)]
             (if-let [jwt (decode raw-jwt pubkey)]
               (if-let [validation-errors
-                       (validate-jwt jwt jwt-max-lifetime-in-sec jwt-check-fn)]
+                       (validate-jwt jwt
+                                     jwt-max-lifetime-in-sec
+                                     jwt-check-fn
+                                     long-lived-jwt?)]
                 (log-and-refuse (pr-str jwt)
                                 (format "(%s) %s"
                                         (or (jwt->user-id jwt) "Unkown User ID")


### PR DESCRIPTION
We want to be able to use long lived JWT.
For that, we need to be able do disable the runtime lifetime check which is generally shorter than just checking the "exp" field in the JWT.

That way we can, for example provide a function that disable that check if the kind of JWT is an OAuth2 refresh-token for example.