### PR TITLE
Generic jwt->identifier support

### DIFF
--- a/src/ring_jwt_middleware/core.clj
+++ b/src/ring_jwt_middleware/core.clj
@@ -172,10 +172,12 @@
   "
   [prefix jwt]
   {:user   (let [user-name (get jwt (str prefix "/user/name"))
-                 user-email (get jwt (str prefix "/user/email"))]
+                 user-email (get jwt (str prefix "/user/email"))
+                 user-idp (get jwt (str prefix "user/idp/id"))]
              (cond-> {:id (jwt->user-id jwt)}
                user-name (assoc :name user-name)
-               user-email (assoc :email user-email)))
+               user-email (assoc :email user-email)
+               user-idp   (assoc :idp user-idp)))
    :scopes (set (get jwt (str prefix "/scopes")))
    :org    (let [org-name (get jwt (str prefix "/org/name"))]
              (cond-> {:id (get jwt (str prefix "/org/id"))}

--- a/test/ring_jwt_middleware/core_test.clj
+++ b/test/ring_jwt_middleware/core_test.clj
@@ -766,16 +766,51 @@
              true))))
 
 (deftest jwt->oauth-ids-test
-  (is (= {:user {:id "user-id"}
-          :org {:id "org-id"}
-          :scopes #{"scope1" "scope2"}
-          :client {:id "client-id"}}
+  (is (= {:scopes #{"scope1" "scope2"},
+          :org {:id "org-id"},
+          :oauth {:client {:id "client-id"}},
+          :user {:id "user-id"}}
          (sut/jwt->oauth-ids
           "http://example.com/claims"
           {:sub "user-id"
            "http://example.com/claims/scopes" ["scope1" "scope2"]
            "http://example.com/claims/org/id" "org-id"
-           "http://example.com/claims/oauth/client/id" "client-id"}))))
+           "http://example.com/claims/oauth/client/id" "client-id"})))
+
+  (is (= {:scopes #{"scope1" "scope2"},
+          :org {:id "org-id"},
+          :oauth {:client {:id "client-id"}},
+          :user {:id "user-id"}}
+         (sut/jwt->oauth-ids
+          "http://example.com/claims"
+          {:sub "user-id"
+           "http://example.com/claims/scopes" ["scope1" "scope2"]
+           "http://example.com/claims/user/id" "BAD-USER-ID"
+           "http://example.com/claims/org/id" "org-id"
+           "http://example.com/claims/oauth/client/id" "client-id"})))
+
+  (is (= {:user
+          {:idp {:name "Visibility", :id "iroh"},
+           :name "John Doe",
+           :email "john.doe@dev.null",
+           :id "user-id"},
+          :oauth {:kind "code", :client {:id "client-id"}},
+          :org {:name "ACME Inc.", :id "org-id"},
+          :scopes #{"scope1" "scope2"}}
+         (sut/jwt->oauth-ids
+          "http://example.com/claims"
+          {:sub "user-id"
+           "http://example.com/claims/scopes" ["scope1" "scope2"]
+           "http://example.com/claims/user/id" "user-id"
+           "http://example.com/claims/user/name" "John Doe"
+           "http://example.com/claims/user/email" "john.doe@dev.null"
+           "http://example.com/claims/user/idp/id" "iroh"
+           "http://example.com/claims/user/idp/name" "Visibility"
+           "http://example.com/claims/org/id" "org-id"
+           "http://example.com/claims/org/name" "ACME Inc."
+           "http://example.com/claims/oauth/client/id" "client-id"
+           "http://example.com/claims/oauth/kind" "code"})))
+  )
 
 (deftest scopes-logic-test
   (is (sut/sub-list ["a" "b"] ["a"]))


### PR DESCRIPTION
Instead of having a fixed list of claims to construct an Identity hash-map.
This PR will help generate any structure depending on the claims of the JWT.