### PR TITLE
removed support for compojure-api / scopes, should be somewhere else

### DIFF
--- a/README.org
+++ b/README.org
@@ -40,7 +40,6 @@ wrap your routes with it:
 | =:jwt-check-fn=            | a fn to custom check the JWT, should return a vec of error strings or nil              | nil                            |
 | =:no-jwt-handler=          | a middleware to pass when no JWT header is found  (=handler -> (request -> response)=) | forbid-no-jwt-header-strategy  |
 | =:post-jwt-format-fn=      | a fn that given a JWT generate an identity information                                 | jwt->user-id (the "sub" claim) |
-| =:long-lived-jwt?=         | a fn that given a JWT return true if we should check the max-lifetime false otherwise  | jwt->user-id (the "sub" claim) |
 
 If the request contains a valid JWT auth header, the JWT is merged with the ring
 request under a =:jwt= key as well with a =:identiy= key.
@@ -83,30 +82,6 @@ here is a sample token:
  :email "foo@bar.com"
  "http://example.com/claim/user/name" "john doe"}
 #+END_SRC
-
-*** Compojure-api support
-
-You can check the JWT from the req with schemas
-and destructure it like the rest of the HTTP query,
-use =:jwt-params=.
-
-#+BEGIN_SRC clojure
-(POST "/test" []
-      :return {:foo s/Str
-               :user_id s/Str}
-               :body-params  [{lorem :- s/Str ""}]
-               :summary "Does nothing"
-               :jwt-params [foo :- s/Str
-                            user_id :- s/Str
-                            exp :- s/Num
-                            {boolean_field :- s/Bool "false"}]
-  {:status 200
-   :body {:foo foo
-          :user_id user_id}})
-#+END_SRC
-
-You could also directly use =:identity= to match the result of the
-=post-jwt-format-fn= applied to the decoded JWT.
 
 ** Generating Certs and a Token
 

--- a/test/ring_jwt_middleware/core_test.clj
+++ b/test/ring_jwt_middleware/core_test.clj
@@ -305,29 +305,18 @@
     (let [post-transform (fn [m] {:user {:id (:sub m)}
                                   :org {:id (:foo m)}})
           wrapper-check (sut/wrap-jwt-auth-fn
-                         {:pubkey-path "resources/cert/ring-jwt-middleware.pub"
-                          :long-lived-jwt? (constantly false)})
-          wrapper-no-check (sut/wrap-jwt-auth-fn
-                            {:pubkey-path "resources/cert/ring-jwt-middleware.pub"
-                             :long-lived-jwt? (constantly true)})
+                         {:pubkey-path "resources/cert/ring-jwt-middleware.pub"})
           ring-fn-1 (wrapper-check
-                     (fn [req] {:status 200
-                                :body (:identity req)}))
-          ring-fn-2 (wrapper-no-check
                      (fn [req] {:status 200
                                 :body (:identity req)}))
           req {:headers {"authorization"
                          (str "Bearer " jwt-token-1)}}]
-      (is (= 401
-             (with-redefs [time/now (constantly (time/date-time 2017 07 1 9 17 4))]
-               (:status (ring-fn-1 req)))))
-      ;; should expire only using :exp not runtime max-jwt-lifetime-in-sec
       (is (= 200
-             (with-redefs [time/now (constantly (time/date-time 2017 07 1 9 17 4))]
-               (:status (ring-fn-2 req)))))
+             (with-redefs [time/now (constantly (time/date-time 2017 07 1 9 17 3))]
+               (:status (ring-fn-1 req)))))
       (is (= 401
              (with-redefs [time/now (constantly (time/date-time 2018 07 1 9 17 4))]
-               (:status (ring-fn-2 req))))))))
+               (:status (ring-fn-1 req))))))))
 
 
 (deftest jwt->oauth-ids-test
@@ -374,8 +363,7 @@
            "http://example.com/claims/org/id" "org-id"
            "http://example.com/claims/org/name" "ACME Inc."
            "http://example.com/claims/oauth/client/id" "client-id"
-           "http://example.com/claims/oauth/kind" "code"})))
-  )
+           "http://example.com/claims/oauth/kind" "code"}))))
 
 
 


### PR DESCRIPTION
With the creation of https://github.com/threatgrid/scopula I think we should get rid of some code and dependency:

- `compojure-api` the `:jwt`, `:scopes`, `:identity` were never used in CTIA and another lib should take care of that "glue" between `scopula`/`compojure-api`/`ring-jwt-middleware`/structured logs.
- scopes logic
