### PR TITLE
Bump deps & release 1.0.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ pom.xml.asc
 .hgignore
 .hg/
 .projectile
+.*.swp

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject threatgrid/ring-jwt-middleware "1.0.1-SNAPSHOT"
+(defproject threatgrid/ring-jwt-middleware "1.0.1"
   :description "A simple middleware to deal with JWT Authentication"
   :pedantic? :abort
   :license {:name "Eclipse Public License - v 1.0"

--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
                  [clj-time "0.15.2"] ;threatgrid/clj-momo > yogsototh/clj-jwt, metosin/compojure-api, metosin/ring-http-response
                  [org.mozilla/rhino "1.7.7.1"] ; metosin/compojure-api > threatgrid/clj-momo
                  [com.google.guava/guava "16.0.1"] ; metosin/compojure-api > threatgrid/clj-momo
-                 [yogsototh/clj-jwt "0.3.0"]
+                 [threatgrid/clj-jwt "0.3.1-20200318.165254-1"] ;sha: fdac01d4c9bea71feec67722ee679be45a21508d
                  [threatgrid/clj-momo "0.3.5"]
                  [org.clojure/tools.logging "1.0.0"]
                  [metosin/ring-http-response "0.9.1"]

--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
                  [clj-time "0.15.2"] ;threatgrid/clj-momo > yogsototh/clj-jwt, metosin/compojure-api, metosin/ring-http-response
                  [org.mozilla/rhino "1.7.7.1"] ; metosin/compojure-api > threatgrid/clj-momo
                  [com.google.guava/guava "16.0.1"] ; metosin/compojure-api > threatgrid/clj-momo
-                 [threatgrid/clj-jwt "0.3.1-20200318.165254-1"] ;sha: fdac01d4c9bea71feec67722ee679be45a21508d
+                 [threatgrid/clj-jwt "0.3.1"]
                  [threatgrid/clj-momo "0.3.5"]
                  [org.clojure/tools.logging "1.0.0"]
                  [metosin/ring-http-response "0.9.1"]

--- a/project.clj
+++ b/project.clj
@@ -1,14 +1,18 @@
 (defproject threatgrid/ring-jwt-middleware "1.0.1-SNAPSHOT"
   :description "A simple middleware to deal with JWT Authentication"
+  :pedantic? :abort
   :license {:name "Eclipse Public License - v 1.0"
             :url "http://www.eclipse.org/legal/epl-v10.html"
             :distribution :repo}
   :url "http://github.com/threatgrid/ring-jwt-middleware"
   :deploy-repositories [["releases" {:url "https://clojars.org/repo" :creds :gpg}]
                         ["snapshots" {:url "https://clojars.org/repo" :creds :gpg}]]
-  :dependencies [[org.clojure/clojure "1.9.0"]
-                 [yogsototh/clj-jwt "0.2.1"]
-                 [threatgrid/clj-momo "0.2.21"]
-                 [org.clojure/tools.logging "0.4.0"]
-                 [metosin/ring-http-response "0.9.0"]
-                 [metosin/compojure-api "1.1.12"]])
+  :dependencies [[org.clojure/clojure "1.10.1"]
+                 [clj-time "0.15.2"] ;threatgrid/clj-momo > yogsototh/clj-jwt, metosin/compojure-api, metosin/ring-http-response
+                 [org.mozilla/rhino "1.7.7.1"] ; metosin/compojure-api > threatgrid/clj-momo
+                 [com.google.guava/guava "16.0.1"] ; metosin/compojure-api > threatgrid/clj-momo
+                 [yogsototh/clj-jwt "0.3.0"]
+                 [threatgrid/clj-momo "0.3.5"]
+                 [org.clojure/tools.logging "1.0.0"]
+                 [metosin/ring-http-response "0.9.1"]
+                 [metosin/compojure-api "1.1.13"]])


### PR DESCRIPTION
Closes #20 

Tested in https://github.com/threatgrid/ctia/pull/885 and https://github.com/threatgrid/iroh/pull/3355

TODO:
- [x] use clj-jwt release jar (from https://github.com/threatgrid/clj-jwt/pull/1)

After merged:
1. Release & tag 1.01
2. Bump to 1.0.2-SNAPSHOT