### PR TITLE
Add :request to infos map for error handlers

### DIFF
--- a/src/ring_jwt_middleware/core.clj
+++ b/src/ring_jwt_middleware/core.clj
@@ -142,7 +142,7 @@
          checks (if (fn? jwt-check-fn)
                   (or (try (seq (jwt-check-fn raw-jwt jwt))
                            (catch Exception e
-                             (log-fn "jwt-check-fn thrown an exception on"
+                             (log-fn "jwt-check-fn threw an exception"
                                      {:level :error
                                       :jwt jwt})
                              (throw e)))
@@ -290,7 +290,7 @@
                                :errors validation-errors})
                 (if (try (is-revoked-fn jwt)
                          (catch Exception e
-                           (structured-log-fn "is-revoked-fn thrown an exception for"
+                           (structured-log-fn "is-revoked-fn threw an exception"
                                               {:level :error
                                                :jwt jwt})
                            (throw e)))

--- a/src/ring_jwt_middleware/core.clj
+++ b/src/ring_jwt_middleware/core.clj
@@ -284,7 +284,8 @@
                 (handle-error (format "(%s) %s"
                                       (or (jwt->user-id jwt) "Unknown User ID")
                                       (str/join ", " validation-errors))
-                              {:jwt jwt
+                              {:request request
+                               :jwt jwt
                                :error :jwt_validation_error
                                :errors validation-errors})
                 (if (try (is-revoked-fn jwt)
@@ -295,11 +296,13 @@
                            (throw e)))
                   (handle-error (format "JWT revoked for %s"
                                         (or (jwt->user-id jwt) "Unknown User ID"))
-                                {:jwt jwt
+                                {:request request
+                                 :jwt jwt
                                  :error :jwt_revoked})
                   (handler (assoc request
                                   :identity (post-jwt-format-fn jwt)
                                   :jwt jwt))))
               (handle-error "Invalid Authorization Header (couldn't verify the JWT signature)"
-                            {:authorization-header (str "Bearer:" raw-jwt)}))
+                            {:request request
+                             :authorization-header (str "Bearer:" raw-jwt)}))
             (no-jwt-fn request)))))))

--- a/test/ring_jwt_middleware/core_test.clj
+++ b/test/ring_jwt_middleware/core_test.clj
@@ -370,15 +370,15 @@
                                    :error-handler error-handler})
           never-revoke (fn [_] false)
           wrapper-never-revoke (sut/wrap-jwt-auth-fn
-                                 {:pubkey-path  "resources/cert/jwt-key-1.pub"
-                                  :is-revoked-fn never-revoke})
+                                {:pubkey-path  "resources/cert/jwt-key-1.pub"
+                                 :is-revoked-fn never-revoke})
           ring-fn-1 (wrapper-always-revoke
-                      (fn [req] {:status 200
-                                 :body (:identity req)}))
+                     (fn [req] {:status 200
+                                :body (:identity req)}))
 
           ring-fn-2 (wrapper-never-revoke
-                      (fn [req] {:status 200
-                                 :body (:identity req)}))
+                     (fn [req] {:status 200
+                                :body (:identity req)}))
           req {:headers {"authorization"
                          (str "Bearer " jwt-token-1)}}
           _ (is (empty? @error-handler-infos-atom))


### PR DESCRIPTION
Related: https://github.com/threatgrid/iroh/issues/4541

Enables error handlers to generate responses in the same format as expected by requests (eg., json, edn). [More context](https://github.com/threatgrid/iroh/issues/4541#issuecomment-790992252).