### PR TITLE
Split middlewares

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,2 @@
+{:lint-as
+ {ring-jwt-middleware.result/let-either clojure.core/let}}

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ pom.xml.asc
 .projectile
 .*.swp
 .clj-kondo/.cache/
+.lsp/.cache/

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ pom.xml.asc
 .hg/
 .projectile
 .*.swp
+.clj-kondo/.cache/

--- a/README.org
+++ b/README.org
@@ -15,11 +15,53 @@ currently, only RS256 is supported.
 
 ** Usage
 
+*** Quickly
 
-*** Example
+If you do not want to use a log middleware:
+
 
 #+begin_src clojure
+(defn my-handler
+  [request]
+  ,,,)
 
+(def jwt-middleware (wrap-jwt-auth-fn {:pubkey-path jwt-cert-path}))
+
+(jwt-middleware my-handler)
+#+end_src
+
+If you want to use a log middleware that will log both user identites
+derived from JWT and response statuses (and other response stats):
+
+#+begin_src clojure
+(defn my-handler
+  [request]
+  ,,,)
+
+(defn wrap-logs
+  "A middleware logging the requests"
+  [handler]
+  (fn [request]
+    (let [user-identity (:identity request)
+          response (handler request)]
+      (log/info (pr-str {:user-identity user-identity
+                         :uri (:uri request)
+                         :status (:status response)}))
+      response)))
+
+(def jwt-middleware
+  (wrap-jwt-auth-with-in-between-middleware-fn
+   {:pubkey-path jwt-cert-path}
+   wrap-logs))
+
+(jwt-middleware my-handler)
+#+end_src
+
+*** Authentication
+
+For Authentication only, and handle the authorization entirely yourself:
+
+#+begin_src clojure
 (defn my-handler
   [request]
   ,,,)
@@ -38,6 +80,7 @@ At this step the ~request~ passed to ~my-handler~ will have some of the followin
 The ~wrap-authentication~ will not take any decision about authorization access.
 This lib also provides another helper to build another middleware handling
 authorization.
+
 You can inject your own authorization rules, via:
 
 #+begin_src clojure
@@ -46,19 +89,9 @@ You can inject your own authorization rules, via:
                             :is-revoked-fn my-revocation-check-fn
                             :jwt-check-fn my-jwt-checks})
       wrap-authorization (mk-wrap-authorization
-                          {:no-jwt-handler my-middleware
-                           :error-handler my-error-handler})]
+                          {:error-handler my-error-handler})]
   (wrap-authentication (wrap-authorization my-handler)))
 #+end_src
-
-**** Notes
-
-There is a distinction between the ~:no-jwt~ error and the other one.
-The main reason being that you should return an error in the ~error-handler~
-while you could still accept un-authenticated access.
-
-If you want to log the calls you should probably add a middleware after
-authentication but before authorization.
 
 *** Options
 
@@ -97,7 +130,7 @@ Notice you could add the following keys in the configuration passed to ~mk-wrap-
                     "The check is considered successful if this function returns nil, or a sequence containing only nil values."))})))
 #+end_src
 
-By default if no JWT auth header is found the request is terminated with
+By default if no JWT authorization header is found the request is terminated with
 =unauthorized= HTTP response.
 
 By default the ~:identity~ contains the ~"sub"~ field of the JWT. But you can
@@ -111,13 +144,13 @@ Currently this middleware only supports JWT using claims registered in the IANA 
 which means you need to generate JWT using most of the claims described here: https://tools.ietf.org/html/rfc7519#section-4
 namely =jti=, =exp=, =iat=, =nbf=, =sub=:
 
-| Claim  | Description                                                        | Format |
-|--------+--------------------------------------------------------------------+--------|
-| =:exp= | Expiration time: https://tools.ietf.org/html/rfc7519#section-4.1.4 | Long   |
-| =:iat= | Issued At: https://tools.ietf.org/html/rfc7519#section-4.1.6       | Long   |
-| =:jti= | JWT ID: https://tools.ietf.org/html/rfc7519#section-4.1.7          | String |
-| =:nbf= | Not Before: https://tools.ietf.org/html/rfc7519#section-4.1.5      | Long   |
-| =:sub= | Subject: https://tools.ietf.org/html/rfc7519#section-4.1.2         | String |
+| Claim | Description                                                        | Format |
+|-------+--------------------------------------------------------------------+--------|
+| =:exp=  | Expiration time: https://tools.ietf.org/html/rfc7519#section-4.1.4 | Long   |
+| =:iat=  | Issued At: https://tools.ietf.org/html/rfc7519#section-4.1.6       | Long   |
+| =:jti=  | JWT ID: https://tools.ietf.org/html/rfc7519#section-4.1.7          | String |
+| =:nbf=  | Not Before: https://tools.ietf.org/html/rfc7519#section-4.1.5      | Long   |
+| =:sub=  | Subject: https://tools.ietf.org/html/rfc7519#section-4.1.2         | String |
 
 here is a sample token:
 

--- a/README.org
+++ b/README.org
@@ -15,6 +15,28 @@ currently, only RS256 is supported.
 
 ** Usage
 
+
+*** Example
+
+#+begin_src clojure
+
+(defn my-handler
+  [request]
+  ,,,)
+
+(let [wrap-authentication
+      (mk-wrap-authentication {:pubkey-path jwt-cert-path})]
+  (wrap-authentication my-handler))
+#+end_src
+
+At this step the ~request~ passed to ~my-handler~ will have some of the following keys added:
+
+- ~jwt~ => the claims of the JWT
+- ~identity~ => the object identity constructed using JWT claims
+- ~jwt-error~ => will contain an error object if the something went wrong with the JWT
+
+
+
 *** Middleware & options
 
 Use =wrap-jwt-auth-fn= to create an instance of the middleware,

--- a/README.org
+++ b/README.org
@@ -32,57 +32,69 @@ currently, only RS256 is supported.
 At this step the ~request~ passed to ~my-handler~ will have some of the following keys added:
 
 - ~jwt~ => the claims of the JWT
-- ~identity~ => the object identity constructed using JWT claims
+- ~identity~ => the object representing the user identity constructed using JWT claims
 - ~jwt-error~ => will contain an error object if the something went wrong with the JWT
 
+The ~wrap-authentication~ will not take any decision about authorization access.
+This lib also provide another helper to build another middleware handling
+authorization.
+You can inject your own authorization rules, via:
 
+#+begin_src clojure
+(let [wrap-authentication (mk-wrap-authentication
+                           {:pubkey-path "/etc/secret/jwt.pub"
+                            :is-revoked-fn my-revocation-check-fn
+                            :jwt-check-fn my-jwt-checks})
+      wrap-authorization (mk-wrap-authorization
+                          {:no-jwt-handler my-middleware
+                           :error-handler my-error-handler})]
+  (wrap-authentication (wrap-authorization my-handler)))
+#+end_src
 
-*** Middleware & options
+**** Notes
 
-Use =wrap-jwt-auth-fn= to create an instance of the middleware,
-wrap your routes with it:
+There is a distinction between the ~:no-jwt~ error and the other one.
+The main reason being that you should return an error in the ~error-handler~
+while you could still accept un-authenticated access.
 
-#+BEGIN_SRC clojure
-(let [wrap-jwt
-      (wrap-jwt-auth-fn {:pubkey-path jwt-cert-path
-                         :is-revoked-fn revoked?
-                         :jwt-max-lifetime-in-sec jwt-lifetime
-                         :jwt-check-fn check-jwt-fields
-                         :no-jwt-handler authorize-no-jwt-header-strategy})]
-  (api (api-data url-prefix)
-        (middleware [wrap-jwt]
-          (routes service url-prefix))))
-#+END_SRC
+If you want to log the calls you should probably add a middleware after
+authentication but before authorization.
 
-| Option                     | Description                                                                            | Default                        |
-|----------------------------+----------------------------------------------------------------------------------------+--------------------------------|
-| =:pubkey-path=             | the path to your public key                                                            | nil                            |
-| =:pubkey-fn=               | A fn from claims to public key, has precedence over pubkey-path                        | nil                            |
-| =:jwt-max-lifetime-in-sec= | set a max lifetime for JWTs to expire                                                  | 86400                          |
-| =:is-revoked-fn=           | a fn to checks if a given JWT should be revoked, should return bool                    | nil                            |
-| =:jwt-check-fn=            | a fn to custom check the JWT, should return a vec of error strings or nil              | nil                            |
+*** Options
+
+Notice you could add the following keys in the configuration passed to ~mk-wrap-authentication~:
+
+1. ~is-revoked-fn~ ; given a decoded JWT should return true or false. If true
+   the request return a 401. If not specified default to ~no-revocation-strategy~.
+2. ~jwt-check-fn~ ; a function that takes two argument the raw JWT and the
+   decoded JWT. This function should return a list of errors. If the list
+   is empty, then the check is successful otherwise return throw a 401.
+
+| Option                   | Description                                                                          | Default                        |
+|--------------------------+--------------------------------------------------------------------------------------+--------------------------------|
+| =:pubkey-path=             | the path to your public key                                                          | nil                            |
+| =:pubkey-fn=               | A fn from claims to public key, has precedence over pubkey-path                      | nil                            |
+| =:jwt-max-lifetime-in-sec= | set a max lifetime for JWTs to expire                                                | 86400                          |
+| =:is-revoked-fn=           | a fn to checks if a given JWT should be revoked, should return bool                  | nil                            |
+| =:jwt-check-fn=            | a fn to custom check the JWT, should return a vec of error strings or nil            | nil                            |
 | =:no-jwt-handler=          | a middleware to pass when no JWT header is found  (=handler -> (request -> response)=) | forbid-no-jwt-header-strategy  |
-| =:post-jwt-format-fn=      | a fn that given a JWT generate an identity information                                 | jwt->user-id (the "sub" claim) |
-
-If the request contains a valid JWT auth header, the JWT is merged with the ring
-request under a =:jwt= key as well with a =:identiy= key.
-Otherwise the request is passed to =:no-jwt-handler=.
+| =:post-jwt-format-fn=      | a fn that given a JWT generate an identity information                               | jwt->user-id (the "sub" claim) |
 
 By default if no JWT auth header is found the request is terminated with
-=unauthorized= HTTP response. You can use =authorize-no-jwt-header-strategy= for
-the =:no-jwt-handler= key if you want to manage how to deal with that case in
-you own handler. You could also provide your own middleware function for this
-case.
+=unauthorized= HTTP response.
+You can use =authorize-no-jwt-header-strategy= for the =:no-jwt-handler= key if
+you want to manage how to deal with that case in you own handler.
+You could also provide your own middleware function for this case.
 
 By default the ~:identity~ contains the ~"sub"~ field of the JWT. But you can
-use more complex transformation. For example, there is a `jwt->oauth-ids`
+use more complex transformation. For example, there is a =jwt->oauth-ids=
 function in the code that could be used to handle JWT generated from an OAuth2
 provider.
 
 *** JWT Format
 
-Currently this middleware only supportes JWTs using claims registered in the IANA "JSON Web Token Claims",
-which means you need to generate JWTs using most of the claims described here: https://tools.ietf.org/html/rfc7519#section-4
+Currently this middleware only supports JWT using claims registered in the IANA "JSON Web Token Claims",
+which means you need to generate JWT using most of the claims described here: https://tools.ietf.org/html/rfc7519#section-4
 namely =jti=, =exp=, =iat=, =nbf=,=sub=:
 
 | Claim  | Description                                                        | Format |
@@ -116,5 +128,5 @@ some dummy ones are already available for easy testing.
 
 ** License
 
-Copyright © 2015-2019 Cisco Systems
+Copyright © 2015-2021 Cisco Systems
 Eclipse Public License v1.0

--- a/README.org
+++ b/README.org
@@ -10,8 +10,8 @@ currently, only RS256 is supported.
 - RS256 signing
 - uses IANA "JSON Web Token Claims"
 - JWT lifetime & Expiration support
-- custom additional validation through a user provided fn
-- custom revokation check through a user provided fn
+- custom additional validation through a user provided functions
+- custom revocation check through a user provided functions
 
 ** Usage
 

--- a/README.org
+++ b/README.org
@@ -62,29 +62,43 @@ authentication but before authorization.
 
 *** Options
 
-Notice you could add the following keys in the configuration passed to ~mk-wrap-authentication~:
+Notice you could add the following keys in the configuration passed to ~mk-wrap-authentication~, ~mk-wrap-authorization~ and ~wrap-jwt-auth-fn:~
 
-1. ~is-revoked-fn~ ; given a decoded JWT should return true or false. If true
-   the request return a 401. If not specified default to ~no-revocation-strategy~.
-2. ~jwt-check-fn~ ; a function that takes two argument the raw JWT and the
-   decoded JWT. This function should return a list of errors. If the list
-   is empty, then the check is successful otherwise return throw a 401.
-
-| Option                   | Description                                                                          | Default                        |
-|--------------------------+--------------------------------------------------------------------------------------+--------------------------------|
-| =:pubkey-path=             | the path to your public key                                                          | nil                            |
-| =:pubkey-fn=               | A fn from claims to public key, has precedence over pubkey-path                      | nil                            |
-| =:jwt-max-lifetime-in-sec= | set a max lifetime for JWTs to expire                                                | 86400                          |
-| =:is-revoked-fn=           | a fn to checks if a given JWT should be revoked, should return bool                  | nil                            |
-| =:jwt-check-fn=            | a fn to custom check the JWT, should return a vec of error strings or nil            | nil                            |
-| =:no-jwt-handler=          | a middleware to pass when no JWT header is found  (=handler -> (request -> response)=) | forbid-no-jwt-header-strategy  |
-| =:post-jwt-format-fn=      | a fn that given a JWT generate an identity information                               | jwt->user-id (the "sub" claim) |
+#+begin_src clojure
+(s/defschema Config
+  "Initialized internal Configuration"
+  (st/merge
+   {:allow-unauthenticated-access?
+    (describe s/Bool
+              "Set this to true to allow unauthenticated requests")
+    :current-epoch
+    (describe (s/=> s/Num)
+              "A function returning the current time in epoch format")
+    :is-revoked-fn
+    (describe (s/=> s/Bool JWTClaims)
+              "A function that take a JWT and return true if it is revoked")
+    :jwt-max-lifetime-in-sec
+    (describe s/Num
+              "Maximal number of second a JWT does not expires")
+    :post-jwt-format-fn
+    (describe (s/=> s/Any JWTClaims)
+              "A function taking the JWT claims and building an Identity object suitable for your needs")
+    :error-handler
+    (describe (s/=> s/Any)
+              "A function that given a JWTError returns a ring response.")}
+   (st/optional-keys
+    {:pubkey-fn (describe (s/=> s/Any s/Str)
+                          "A function returning a public key (takes precedence over pubkey-path)")
+     :pubkey-path (describe s/Str
+                            "The path to find the public key that will be used to check the JWT signature")
+     :jwt-check-fn
+     (describe (s/=> s/Bool JWT JWTClaims)
+               (str "A function that take a JWT, claims and return a sequence of string containing errors."
+                    "The check is considered successful if this function returns nil, or a sequence containing only nil values."))})))
+#+end_src
 
 By default if no JWT auth header is found the request is terminated with
 =unauthorized= HTTP response.
-You can use =authorize-no-jwt-header-strategy= for the =:no-jwt-handler= key if
-you want to manage how to deal with that case in you own handler.
-You could also provide your own middleware function for this case.
 
 By default the ~:identity~ contains the ~"sub"~ field of the JWT. But you can
 use more complex transformation. For example, there is a =jwt->oauth-ids=
@@ -95,7 +109,7 @@ provider.
 
 Currently this middleware only supports JWT using claims registered in the IANA "JSON Web Token Claims",
 which means you need to generate JWT using most of the claims described here: https://tools.ietf.org/html/rfc7519#section-4
-namely =jti=, =exp=, =iat=, =nbf=,=sub=:
+namely =jti=, =exp=, =iat=, =nbf=, =sub=:
 
 | Claim  | Description                                                        | Format |
 |--------+--------------------------------------------------------------------+--------|

--- a/README.org
+++ b/README.org
@@ -10,8 +10,8 @@ currently, only RS256 is supported.
 - RS256 signing
 - uses IANA "JSON Web Token Claims"
 - JWT lifetime & Expiration support
-- custom additional validation through a user provided functions
-- custom revocation check through a user provided functions
+- custom additional validation through user-provided functions
+- custom revocation check through user-provided functions
 
 ** Usage
 
@@ -36,7 +36,7 @@ At this step the ~request~ passed to ~my-handler~ will have some of the followin
 - ~jwt-error~ => will contain an error object if the something went wrong with the JWT
 
 The ~wrap-authentication~ will not take any decision about authorization access.
-This lib also provide another helper to build another middleware handling
+This lib also provides another helper to build another middleware handling
 authorization.
 You can inject your own authorization rules, via:
 

--- a/project.clj
+++ b/project.clj
@@ -12,4 +12,4 @@
                  [org.clojure/tools.logging "1.0.0"]
                  [metosin/ring-http-response "0.9.1"]]
   :profiles {:dev {:pedantic? :warn
-                   :dependencies [[threatgrid/clj-momo "0.3.5"]]}})
+                   :dependencies [[clojure.java-time "0.3.3"]]}})

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject threatgrid/ring-jwt-middleware "1.0.3-SNAPSHOT"
+(defproject threatgrid/ring-jwt-middleware "1.1.0-SNAPSHOT"
   :description "A simple middleware to deal with JWT Authentication"
   :pedantic? :abort
   :license {:name "Eclipse Public License - v 1.0"
@@ -9,7 +9,7 @@
                         ["snapshots" {:url "https://clojars.org/repo" :creds :gpg}]]
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [threatgrid/clj-jwt "0.3.1"]
-                 [threatgrid/clj-momo "0.3.5"]
                  [org.clojure/tools.logging "1.0.0"]
                  [metosin/ring-http-response "0.9.1"]]
-  :profiles {:dev {:pedantic? :warn}})
+  :profiles {:dev {:pedantic? :warn
+                   :dependencies [[threatgrid/clj-momo "0.3.5"]]}})

--- a/project.clj
+++ b/project.clj
@@ -10,6 +10,8 @@
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [threatgrid/clj-jwt "0.3.1"]
                  [org.clojure/tools.logging "1.0.0"]
-                 [metosin/ring-http-response "0.9.1"]]
+                 [metosin/ring-http-response "0.9.1"]
+                 [prismatic/schema "1.1.12"]
+                 [metosin/schema-tools "0.12.3"]]
   :profiles {:dev {:pedantic? :warn
                    :dependencies [[clojure.java-time "0.3.3"]]}})

--- a/src/ring_jwt_middleware/config.clj
+++ b/src/ring_jwt_middleware/config.clj
@@ -1,8 +1,8 @@
 (ns ring-jwt-middleware.config
-  (:require [clojure.tools.logging :as log]
+  (:require [clojure.string :as string]
+            [clojure.tools.logging :as log]
             [ring-jwt-middleware.schemas :refer [Config JWTClaims UserConfig]]
             [ring.util.http-response :as resp]
-            [clojure.string :as string]
             [schema.core :as s]))
 
 (s/defn current-epoch! :- s/Num

--- a/src/ring_jwt_middleware/config.clj
+++ b/src/ring_jwt_middleware/config.clj
@@ -98,7 +98,6 @@
         (update-if-contains? :scopes set) ;; and scopes should be a set, not alist
         )))
 
-
 (def default-config
   {:allow-unauthenticated-access? false
    :current-epoch current-epoch!

--- a/src/ring_jwt_middleware/config.clj
+++ b/src/ring_jwt_middleware/config.clj
@@ -1,0 +1,130 @@
+(ns ring-jwt-middleware.config
+  (:require [clojure.tools.logging :as log]
+            [ring-jwt-middleware.schemas :refer [Config JWTClaims UserConfig]]
+            [ring.util.http-response :as resp]
+            [clojure.string :as string]
+            [schema.core :as s]))
+
+(s/defn current-epoch! :- s/Num
+  "Returns the current time in epoch"
+  []
+  (quot (System/currentTimeMillis) 1000))
+
+(defn default-error-handler
+  "Return an `unauthorized` HTTP response and log the error along debug infos"
+  [{:keys [error error_description] :as error-data}]
+  (log/infof "%s: %s %s" error error_description (dissoc error-data :error :error_description :raw_jwt))
+  (resp/unauthorized (dissoc error-data :raw_jwt)))
+
+(def default-jwt-lifetime-in-sec
+  "Default JWT lifetime is 24h"
+  86400)
+
+(def no-revocation-strategy
+  "The default function used for `:is-revoked-fn` configuration"
+  (constantly false))
+
+(defn forbid-no-jwt-header-strategy
+  "Forbid all request with no Auth header"
+  [_handler]
+  (constantly
+   (resp/unauthorized {:error :invalid_request
+                       :error_description "No Authorization Header"})))
+
+(def authorize-no-jwt-header-strategy
+  "Authorize all request even with no Auth header."
+  identity)
+
+(s/defn jwt->user-id :- s/Str
+  "can be used as post-jwt-format-fn"
+  [jwt :- JWTClaims]
+  (:sub jwt))
+
+(s/defn jwt->oauth-ids
+  "can be used as post-jwt-format-fn
+
+  This is an example function that given a JWT whose claims looks like:
+
+  - :sub
+  - \"<prefix>/scopes\"
+  - \"<prefix>/org/id\"
+  - \"<prefix>/oauth/client/id\"
+
+  It is a generic format about what an access-token should provide:
+
+  - user-id, client-id, scopes
+  - org-id
+
+  mainly transform a list of <prefix>/foo/bar/baz value into a deep nested map.
+  For example:
+
+  (sut/jwt->oauth-ids
+          \"http://example.com/claims\"
+          {:sub \"user-id\"
+           \"http://example.com/claims/scopes\" [\"scope1\" \"scope2\"]
+           \"http://example.com/claims/user/id\" \"user-id\"
+           \"http://example.com/claims/user/name\" \"John Doe\"
+           \"http://example.com/claims/user/email\" \"john.doe@dev.null\"
+           \"http://example.com/claims/user/idp/id\" \"iroh\"
+           \"http://example.com/claims/user/idp/name\" \"Visibility\"
+           \"http://example.com/claims/org/id\" \"org-id\"
+           \"http://example.com/claims/org/name\" \"ACME Inc.\"
+           \"http://example.com/claims/oauth/client/id\" \"client-id\"
+           \"http://example.com/claims/oauth/kind\" \"code\"})
+
+  => {:user {:idp {:name \"Visibility\"
+                   :id \"iroh\"},
+             :name \"John Doe\",
+             :email \"john.doe@dev.null\",
+             :id \"user-id\"}
+      :oauth {:kind \"code\"
+              :client {:id \"client-id\"}},
+      :org   {:name \"ACME Inc.\"
+              :id \"org-id\"},
+      :scopes #{\"scope1\" \"scope2\"}}
+  "
+  [prefix :- s/Str
+   jwt :- JWTClaims]
+  (let [n (+ 1 (count prefix))
+        update-if-contains? (fn [m k f]
+                              (if (contains? m k)
+                                (update m k f)
+                                m))
+        keywordize #(map keyword %)
+        str-to-path (fn [k]
+                      (-> k ;; the key of the jwt map that starts with prefix
+                          (subs n) ;; remove the prefix
+                          (string/split #"/") ;; split on /
+                          ;; finally keywordize all elements
+                          keywordize))
+        tmp (->> jwt
+                 (map (fn [[k v]]
+                        (when (and (string? k) (string/starts-with? k prefix))
+                          [(str-to-path k) v])))
+                 (remove nil?) ;; remove key not starting by prefix
+                 (reduce (fn [acc [kl v]] (assoc-in acc kl v)) {}) ;; construct the hash-map
+                 )]
+    (-> tmp
+        (assoc-in [:user :id] (:sub jwt)) ;; :sub overwrite any :user :id
+        (update-if-contains? :scopes set) ;; and scopes should be a set, not alist
+        )))
+
+
+(def default-config
+  {:allow-unauthenticated-access? false
+   :current-epoch current-epoch!
+   :is-revoked-fn (constantly false)
+   :jwt-max-lifetime-in-sec default-jwt-lifetime-in-sec
+   :post-jwt-format-fn jwt->user-id})
+
+(defn conf-valid?
+  [{:keys [pubkey-path pubkey-fn] :as conf}]
+  (s/validate Config conf)
+  (assert (or pubkey-path pubkey-fn)
+          "The configuration should provide at least one of `pubkey-path` or `pukey-fn`"))
+
+(s/defn ->config :- Config
+  [user-config :- UserConfig]
+  (let [config (into default-config user-config)]
+    (conf-valid? config)
+    config))

--- a/src/ring_jwt_middleware/core.clj
+++ b/src/ring_jwt_middleware/core.clj
@@ -235,3 +235,17 @@
   (let [wrap-authentication (mk-wrap-authentication conf)
         wrap-authorization (mk-wrap-authorization conf)]
     (comp wrap-authentication wrap-authorization)))
+
+(defn wrap-jwt-auth-with-in-between-middleware-fn
+  "Wrap the JWT authentication, authorization and a middleware wrapper in the middle
+
+  The wrapper will have access to both:
+  - the request with JWT details added by the authentication layer
+  - the response status returned by the authorization layer.
+
+  This is a good place to put a log middlware that will log all requests
+  "
+  [conf wrap-logs]
+  (let [wrap-authentication (mk-wrap-authentication conf)
+        wrap-authorization (mk-wrap-authorization conf)]
+    (comp wrap-authentication wrap-logs wrap-authorization)))

--- a/src/ring_jwt_middleware/result.clj
+++ b/src/ring_jwt_middleware/result.clj
@@ -34,8 +34,8 @@
    (s/optional-key :jwt-error) JwtError})
 
 (s/defschema Result
-  ;; A result is similar to the Either in Haskell
-  ;; It represent either a value or an error
+  "A result is similar to the Either in Haskell
+   It represent either a value or an error"
   (result-of s/Any))
 
 (s/defn ->pure :- Result

--- a/src/ring_jwt_middleware/result.clj
+++ b/src/ring_jwt_middleware/result.clj
@@ -1,9 +1,9 @@
 (ns ring-jwt-middleware.result
-  "This ns provide a set of helpers to handle an abstraction similar to Either in Haskell
+  "This ns provides a set of helpers to handle an abstraction similar to Either in Haskell.
 
-  The main goal is to provide a mechanism similar to the exceptions but pure without Java Exceptions.
+  The main goal is to provide a mechanism similar to the exceptions, albeit pure - without Java Exceptions.
 
-  A function that return a `Result` means the function returned either a successful result or an error with a
+  When a function returns a `Result` - it either contains a result of a successful outcome or an error with a
   common error structure (`JwtError`).
 
   The `let-either` macro provides a monadic syntax.

--- a/src/ring_jwt_middleware/result.clj
+++ b/src/ring_jwt_middleware/result.clj
@@ -71,11 +71,9 @@
     (:result result)))
 
 (defmacro let-either
-  "The let-either macro can be used to handle cascading results that
-  can depend on preceding values.
+  "To be used to handle cascading results that may depend on preceding values.
   If one of the function fail, we return the failed result.
-  If all functions are successful we return the content of the
-  body."
+  If all functions are successful we return the content of the body."
   {:special-form true
    :forms '[(let-either [bindings*] exprs*)]
    :style/indent 1}

--- a/src/ring_jwt_middleware/result.clj
+++ b/src/ring_jwt_middleware/result.clj
@@ -2,18 +2,24 @@
   (:require [schema.core :as s]
             [schema-tools.core :as st]))
 
-(s/defschema Result
-  {(s/optional-key :result) s/Any
-   (s/optional-key :jwt-error)
-   (st/open-schema
+(s/defschema JwtError
+  (st/open-schema
     {:error s/Keyword
-     :error_description s/Str})})
+     :error_description s/Str}))
+
+(s/defschema Result
+  ;; A result is similar to the Either in Haskell
+  ;; It represent either a value or an error
+  {(s/optional-key :result) s/Any
+   (s/optional-key :jwt-error) JwtError})
 
 (s/defn ->pure :- Result
+  "given a value build a result containing this value"
   [v]
   {:result v})
 
 (s/defn ->err :- Result
+  "build a Result that contain an error."
   [err-code :- s/Keyword
    err-description :- s/Str
    error-metas :- {s/Any s/Any}]
@@ -23,14 +29,17 @@
           :error_description err-description})})
 
 (s/defn error? :- s/Bool
+  "return true if the given result is an Error"
   [m :- Result]
   (boolean (get m :jwt-error)))
 
 (s/defn success? :- s/Bool
+  "return true if the given result is not an Error"
   [m :- Result]
   (not (error? m)))
 
 (s/defn <-result :- s/Any
+  "Either returns the value or the error contained in the Result"
   [result :- Result]
   (if (error? result)
     result

--- a/src/ring_jwt_middleware/result.clj
+++ b/src/ring_jwt_middleware/result.clj
@@ -7,11 +7,14 @@
     {:error s/Keyword
      :error_description s/Str}))
 
+(s/defn result-of [s]
+  {(s/optional-key :result) s
+   (s/optional-key :jwt-error) JwtError})
+
 (s/defschema Result
   ;; A result is similar to the Either in Haskell
   ;; It represent either a value or an error
-  {(s/optional-key :result) s/Any
-   (s/optional-key :jwt-error) JwtError})
+  (result-of s/Any))
 
 (s/defn ->pure :- Result
   "given a value build a result containing this value"

--- a/src/ring_jwt_middleware/result.clj
+++ b/src/ring_jwt_middleware/result.clj
@@ -16,7 +16,7 @@
     ,,,)
   ```
 
-  if `fn-returning-a-result-1` return an error then we will not execute the rest of the let-either.
+  if `fn-returning-a-result-1` returns an error then we will not execute the rest of the let-either.
   And return the full `result`.
   "
   (:require [schema.core :as s]

--- a/src/ring_jwt_middleware/result.clj
+++ b/src/ring_jwt_middleware/result.clj
@@ -1,0 +1,37 @@
+(ns ring-jwt-middleware.result
+  (:require [schema.core :as s]
+            [schema-tools.core :as st]))
+
+(s/defschema Result
+  {(s/optional-key :result) s/Any
+   (s/optional-key :jwt-error)
+   (st/open-schema
+    {:error s/Keyword
+     :error_description s/Str})})
+
+(s/defn ->pure :- Result
+  [v]
+  {:result v})
+
+(s/defn ->err :- Result
+  [err-code :- s/Keyword
+   err-description :- s/Str
+   error-metas :- {s/Any s/Any}]
+  {:jwt-error
+   (into error-metas
+         {:error err-code
+          :error_description err-description})})
+
+(s/defn error? :- s/Bool
+  [m :- Result]
+  (boolean (get m :jwt-error)))
+
+(s/defn success? :- s/Bool
+  [m :- Result]
+  (not (error? m)))
+
+(s/defn <-result :- s/Any
+  [result :- Result]
+  (if (error? result)
+    result
+    (:result result)))

--- a/src/ring_jwt_middleware/result.clj
+++ b/src/ring_jwt_middleware/result.clj
@@ -1,4 +1,28 @@
 (ns ring-jwt-middleware.result
+  "This ns provide a set of helpers to handle an abstraction similar to Either in Haskell
+
+  The main goal is to provide a mechanism similar to the exceptions but pure without Java Exceptions.
+
+  A function that return a `Result` means the function returned either a successful result or an error with a
+  common error structure (`JwtError`).
+
+  As the code is quite minimal I didn't introduce a `let-either` macro to simulate a monadic notation.
+  And instead manage the dispatch manually via:
+
+  ```
+  (let [x (fn-returning-a-result ,,,)]
+    (if (error? x)
+       x
+       (let [return-value (<-result x)]
+         ,,,,)))
+  ```
+
+  Which while a bit cumbersome is probably easier to understand.
+  And also for some retro-compatibily reason this is not _the_ right monadic pattern
+  (we should use (<-result x) in case of error)
+
+  Whatever, this is still a pretty usefule abstraction even without going very deep.
+  "
   (:require [schema.core :as s]
             [schema-tools.core :as st]))
 
@@ -7,7 +31,9 @@
     {:error s/Keyword
      :error_description s/Str}))
 
-(s/defn result-of [s]
+(s/defn result-of
+  "Build a schema representing a result expecting succesful result with schema `s`"
+  [s]
   {(s/optional-key :result) s
    (s/optional-key :jwt-error) JwtError})
 

--- a/src/ring_jwt_middleware/schemas.clj
+++ b/src/ring_jwt_middleware/schemas.clj
@@ -1,8 +1,7 @@
 (ns ring-jwt-middleware.schemas
   "Schemas used"
-  (:require
-   [schema.core :as s]
-   [schema-tools.core :as st]))
+  (:require [schema-tools.core :as st]
+            [schema.core :as s]))
 
 ;; Schemas
 (s/defschema KeywordOrString

--- a/src/ring_jwt_middleware/schemas.clj
+++ b/src/ring_jwt_middleware/schemas.clj
@@ -1,0 +1,67 @@
+(ns ring-jwt-middleware.schemas
+  "Schemas used"
+  (:require
+   [schema.core :as s]
+   [schema-tools.core :as st]))
+
+;; Schemas
+(s/defschema KeywordOrString
+  (s/conditional keyword? s/Keyword
+                 :else s/Str))
+
+(def JWT
+  "A JWT is just a string"
+  s/Str)
+
+(s/defschema JWTClaims
+  (st/merge
+   (st/optional-keys
+    {:exp s/Num
+     :nbf s/Num
+     :iat s/Num
+     :iss s/Str
+     :sub s/Str
+     :aud (s/conditional string? s/Str :else [s/Str])
+     :user_email s/Str})
+   {KeywordOrString s/Any}))
+
+(defn describe
+  "A function adding a description meta to schema.
+  This help schema as documentation."
+  [s description]
+  (if (instance? clojure.lang.IObj s)
+    (with-meta s {:description description})
+    s))
+
+(s/defschema Config
+  "Initialized internal Configuration"
+  (st/merge
+   {:allow-unauthenticated-access?
+    (describe s/Bool
+              "Set this to true to allow unauthenticated requests")
+    :current-epoch
+    (describe (s/=> s/Num)
+              "A function returning the current time in epoch format")
+    :is-revoked-fn
+    (describe (s/=> s/Bool JWTClaims)
+              "A function that take a JWT and return true if it is revoked")
+    :jwt-max-lifetime-in-sec
+    (describe s/Num
+              "Maximal number of second a JWT does not expires")
+    :post-jwt-format-fn
+    (describe (s/=> s/Any JWTClaims)
+              "A function taking the JWT claims and building an Identity object suitable for your needs")}
+   (st/optional-keys
+    {:pubkey-fn (describe (s/=> s/Any s/Str)
+                          "A function returning a public key (takes precedence over pubkey-path)")
+     :pubkey-path (describe s/Str
+                            "The path to find the public key that will be used to check the JWT signature")
+     :jwt-check-fn
+     (describe (s/=> s/Bool JWT JWTClaims)
+               (str "A function that take a JWT, claims and return a sequence of string containing errors."
+                    "The check is considered successful if this function returns nil, or a sequence containing only nil values."))})))
+
+
+(s/defschema UserConfig
+  "Middleware Configuration"
+  (st/optional-keys Config))

--- a/src/ring_jwt_middleware/schemas.clj
+++ b/src/ring_jwt_middleware/schemas.clj
@@ -1,9 +1,8 @@
 (ns ring-jwt-middleware.schemas
-  "Schemas used"
+  "Schemas"
   (:require [schema-tools.core :as st]
             [schema.core :as s]))
 
-;; Schemas
 (s/defschema KeywordOrString
   (s/conditional keyword? s/Keyword
                  :else s/Str))
@@ -26,7 +25,7 @@
 
 (defn describe
   "A function adding a description meta to schema.
-  This help schema as documentation."
+  The main purpose is just schema annotation for the developers."
   [s description]
   (if (instance? clojure.lang.IObj s)
     (with-meta s {:description description})

--- a/src/ring_jwt_middleware/schemas.clj
+++ b/src/ring_jwt_middleware/schemas.clj
@@ -50,7 +50,10 @@
               "Maximal number of second a JWT does not expires")
     :post-jwt-format-fn
     (describe (s/=> s/Any JWTClaims)
-              "A function taking the JWT claims and building an Identity object suitable for your needs")}
+              "A function taking the JWT claims and building an Identity object suitable for your needs")
+    :error-handler
+    (describe (s/=> s/Any)
+              "A function that given a JWTError returns a ring response.")}
    (st/optional-keys
     {:pubkey-fn (describe (s/=> s/Any s/Str)
                           "A function returning a public key (takes precedence over pubkey-path)")

--- a/test/ring_jwt_middleware/config_test.clj
+++ b/test/ring_jwt_middleware/config_test.clj
@@ -1,0 +1,71 @@
+(ns ring-jwt-middleware.config-test
+  (:require [ring-jwt-middleware.config :as sut]
+            [clojure.test :as t])
+  (:import java.lang.AssertionError))
+
+(t/deftest init-config-test
+  (t/is (= (str "Assert failed:"
+                " The configuration should provide at least one of "
+                "`pubkey-path` or `pukey-fn`"
+                "\n(or pubkey-path pubkey-fn)")
+           (try
+             (sut/->config {})
+             (catch AssertionError e (.getMessage e)))))
+
+  (t/is (= {:allow-unauthenticated-access? false
+            :current-epoch sut/current-epoch!
+            :is-revoked-fn sut/no-revocation-strategy
+            :jwt-max-lifetime-in-sec 86400
+            :post-jwt-format-fn sut/jwt->user-id
+            :pubkey-path "/some/path"
+            :error-handler sut/default-error-handler}
+           (sut/->config {:pubkey-path "/some/path"})))
+
+  (t/is (sut/->config {:pubkey-fn (constantly "/some/path")})
+        "providing a pubkey-fn should be enough"))
+
+(t/deftest jwt->oauth-ids-test
+  (t/is (= {:scopes #{"scope1" "scope2"},
+            :org {:id "org-id"},
+            :oauth {:client {:id "client-id"}},
+            :user {:id "user-id"}}
+           (sut/jwt->oauth-ids
+            "http://example.com/claims"
+            {:sub "user-id"
+             "http://example.com/claims/scopes" ["scope1" "scope2"]
+             "http://example.com/claims/org/id" "org-id"
+             "http://example.com/claims/oauth/client/id" "client-id"})))
+
+  (t/is (= {:scopes #{"scope1" "scope2"},
+            :org {:id "org-id"},
+            :oauth {:client {:id "client-id"}},
+            :user {:id "user-id"}}
+           (sut/jwt->oauth-ids
+            "http://example.com/claims"
+            {:sub "user-id"
+             "http://example.com/claims/scopes" ["scope1" "scope2"]
+             "http://example.com/claims/user/id" "BAD-USER-ID"
+             "http://example.com/claims/org/id" "org-id"
+             "http://example.com/claims/oauth/client/id" "client-id"})))
+
+  (t/is (= {:user
+            {:idp {:name "Visibility", :id "iroh"},
+             :name "John Doe",
+             :email "john.doe@dev.null",
+             :id "user-id"},
+            :oauth {:kind "code", :client {:id "client-id"}},
+            :org {:name "ACME Inc.", :id "org-id"},
+            :scopes #{"scope1" "scope2"}}
+           (sut/jwt->oauth-ids
+            "http://example.com/claims"
+            {:sub "user-id"
+             "http://example.com/claims/scopes" ["scope1" "scope2"]
+             "http://example.com/claims/user/id" "user-id"
+             "http://example.com/claims/user/name" "John Doe"
+             "http://example.com/claims/user/email" "john.doe@dev.null"
+             "http://example.com/claims/user/idp/id" "iroh"
+             "http://example.com/claims/user/idp/name" "Visibility"
+             "http://example.com/claims/org/id" "org-id"
+             "http://example.com/claims/org/name" "ACME Inc."
+             "http://example.com/claims/oauth/client/id" "client-id"
+             "http://example.com/claims/oauth/kind" "code"}))))

--- a/test/ring_jwt_middleware/config_test.clj
+++ b/test/ring_jwt_middleware/config_test.clj
@@ -1,6 +1,6 @@
 (ns ring-jwt-middleware.config-test
-  (:require [ring-jwt-middleware.config :as sut]
-            [clojure.test :as t])
+  (:require [clojure.test :as t]
+            [ring-jwt-middleware.config :as sut])
   (:import java.lang.AssertionError))
 
 (t/deftest init-config-test

--- a/test/ring_jwt_middleware/core_test.clj
+++ b/test/ring_jwt_middleware/core_test.clj
@@ -169,29 +169,29 @@
          (sut/validate-jwt "jwt" {:user-identifier "foo@bar.com"
                             :iat 1487168050} 86400 test-log-fn)))
   (testing "check-fn throw an exception"
-    (is (= "check-fn fail test"
-           (try
-             (sut/validate-jwt "jwt"
-                               decoded-jwt-1
-                               86400
-                               (fn [raw-jwt jwt] (throw (ex-info "check-fn fail test" {:test-infos :test})))
-                               test-log-fn)
-             (catch Exception e (.getMessage e)))))
-    (is (= [{:msg "jwt-check-fn thrown an exception on",
-             :infos
-             {:level :error,
-              :raw-jwt "jwt"
-              :jwt
-              {:jti "r3e03ac6e-8d09-4d5e-8598-30e51a26dd2d",
-               :exp 1499419023,
-               :iat 1498814223,
-               :nbf 1498813923,
-               :sub "foo@bar.com",
-               :iss "TEST-ISSUER-1"
-               :user-identifier "foo@bar.com",
-               :user_id "f0010924-e1bc-4b03-b600-89c6cf52757c",
-               :foo "bar"}}}]
-           @log-events))
+    (is (= {:jwt-error
+            {:level :error,
+             :raw-jwt "jwt",
+             :jwt
+             {:user-identifier "foo@bar.com",
+              :sub "foo@bar.com",
+              :iss "TEST-ISSUER-1",
+              :exp 1499419023,
+              :jti "r3e03ac6e-8d09-4d5e-8598-30e51a26dd2d",
+              :nbf 1498813923,
+              :foo "bar",
+              :user_id "f0010924-e1bc-4b03-b600-89c6cf52757c",
+              :iat 1498814223},
+             :error :jwt-custom-check-exception,
+             :error_description "jwt-check-fn thrown an exception"}}
+           (-> (try
+                 (sut/validate-jwt "jwt"
+                                   decoded-jwt-1
+                                   86400
+                                   (fn [raw-jwt jwt] (throw (ex-info "check-fn fail test" {:test-infos :test})))
+                                   test-log-fn)
+                 (catch Exception e (.getMessage e)))
+               (update :jwt-error dissoc :exception))))
     (reset-log-events))
 
   (testing "check-fn fail by using the raw-jwt"

--- a/test/ring_jwt_middleware/core_test.clj
+++ b/test/ring_jwt_middleware/core_test.clj
@@ -14,13 +14,6 @@
       (time/date-time 2017 06 30 9 35 2))]
     (f)))
 
-
-(defn with-fixed-uuid
-  [f]
-  (with-redefs
-    [sut/gen-uuid (constantly "00000000-0000-0000-0000-000000000000")]
-    (f)))
-
 (defn make-jwt
   "a useful one liner for easy testing"
   [input-map privkey-name]
@@ -42,11 +35,10 @@
   (reset! log-events []))
 
 (defn with-clean-event-logs [f]
-  (do (reset-log-events)
-      (f)))
+  (reset-log-events)
+  (f))
 
-(use-fixtures :once (join-fixtures [with-fixed-time
-                                    with-fixed-uuid]))
+(use-fixtures :once (join-fixtures [with-fixed-time]))
 
 (use-fixtures :each with-clean-event-logs)
 

--- a/test/ring_jwt_middleware/core_test.clj
+++ b/test/ring_jwt_middleware/core_test.clj
@@ -133,9 +133,8 @@
              (select-keys [:error :error_description])))))
 
 (deftest validate-errors-test
-  (let [cfg {:jwt-max-lifetime-in-sec nil
-             :jwt-check-fn nil
-             :current-epoch fixed-current-epoch}]
+  (let [cfg (sut/->config {:current-epoch fixed-current-epoch
+                           :pubkey-path "resources/cert/jwt-key-1.pub"})]
 
     (is (result/success? (sut/validate-jwt cfg "jwt" decoded-jwt-1)))
     (is (= {:jwt-error {:jwt {}
@@ -305,7 +304,7 @@
   (testing "Authorized No Auth Header strategy test"
     (let [wrapper (sut/wrap-jwt-auth-fn
                    {:pubkey-path "resources/cert/jwt-key-1.pub"
-                    :allow-unauthenticated? true})
+                    :allow-unauthenticated-access? true})
           ring-fn-1 (wrapper (fn [req] {:status 200
                                         :body (:identity req)}))
           ring-fn-2 (wrapper (fn [req] {:status 200


### PR DESCRIPTION
> Related https://github.com/advthreat/iroh/pull/5749

Code refacto to split the single main `wrap-jwt` middleware in two `wrap-authorization` and `wrap-authentication`.

Removed a lot of unnecessary injection and coupling.

- Removed the dependency from `clj-momo`. Now we only use `clojure.java-time` for tests.
- Added schemas.
- Prevent log function injection (and some others) by preventing exceptions.
