### PR TITLE
Support missing nbf JWT

### DIFF
--- a/README.org
+++ b/README.org
@@ -123,7 +123,11 @@ Notice you could add the following keys in the configuration passed to ~mk-wrap-
               "A function taking the JWT claims and building an Identity object suitable for your needs")
     :error-handler
     (describe (s/=> s/Any)
-              "A function that given a JWTError returns a ring response.")}
+              "A function that given a JWTError returns a ring response.")
+
+    :default-allowed-clock-skew-in-seconds
+    (describe s/Num
+              "When the JWT does not contain any nbf claim, the number of seconds to remove from iat claim. Default 60.")}
    (st/optional-keys
     {:pubkey-fn (describe (s/=> s/Any s/Str)
                           "A function returning a public key (takes precedence over pubkey-path)")

--- a/src/ring_jwt_middleware/config.clj
+++ b/src/ring_jwt_middleware/config.clj
@@ -105,6 +105,7 @@
 
 (def default-config
   {:allow-unauthenticated-access? false
+   :default-allowed-clock-skew-in-seconds 60
    :current-epoch current-epoch!
    :is-revoked-fn no-revocation-strategy
    :jwt-max-lifetime-in-sec default-jwt-lifetime-in-sec

--- a/src/ring_jwt_middleware/schemas.clj
+++ b/src/ring_jwt_middleware/schemas.clj
@@ -62,7 +62,11 @@
               "A function taking the JWT claims and building an Identity object suitable for your needs")
     :error-handler
     (describe (s/=> s/Any)
-              "A function that given a JWTError returns a ring response.")}
+              "A function that given a JWTError returns a ring response.")
+
+    :default-allowed-clock-skew-in-seconds
+    (describe s/Num
+              "When the JWT does not contain any nbf claim, the number of seconds to remove from iat claim. Default 60.")}
    (st/optional-keys
     {:pubkey-fn (describe (s/=> s/Any s/Str)
                           "A function returning a public key (takes precedence over pubkey-path)")

--- a/test/ring_jwt_middleware/config_test.clj
+++ b/test/ring_jwt_middleware/config_test.clj
@@ -13,6 +13,7 @@
              (catch AssertionError e (.getMessage e)))))
 
   (t/is (= {:allow-unauthenticated-access? false
+            :default-allowed-clock-skew-in-seconds 60,
             :current-epoch sut/current-epoch!
             :is-revoked-fn sut/no-revocation-strategy
             :jwt-max-lifetime-in-sec 86400


### PR DESCRIPTION
Support JWT without `nbf` claim.

By default we override the default by accepting nonetheless 1min clock skew.